### PR TITLE
Funkcja do drukowania zwrotek

### DIFF
--- a/szablon/struktura-zwrotek-redone.ily
+++ b/szablon/struktura-zwrotek-redone.ily
@@ -1,0 +1,42 @@
+\version "2.17.3"
+
+zwrotki = #(define-scheme-function
+		(parser location zwrotki)
+		(markup-list?)
+	(let ((powiekszenie-zwrotek '(1.1 . 1.1))
+				(interlinia '(baseline-skip . 3))
+				(odstepOdNumeruDoZwrotki 1)
+				(odstepMiedzyZwrotkami 2)
+				(counter 2))
+	#{
+		\markup {
+			\fill-line {
+				\scale #powiekszenie-zwrotek {
+					\null
+
+					\override #interlinia
+					\column {
+						
+						#(map
+							(lambda (x) #{ \markup {
+							\line {
+								\bold
+								{ #(object->string counter)  "."}
+								\hspace #odstepOdNumeruDoZwrotki
+								#(car zwrotki)
+								#(begin (set! zwrotki (cdr zwrotki)) (set! counter (+ counter 1)) #{ \markup {} #})
+							}
+							\vspace #odstepMiedzyZwrotkami }
+					
+						#})
+						zwrotki)
+
+					}
+
+					\null
+
+				}
+			}
+		}
+
+	#}))

--- a/szablon/struktura-zwrotek-redone.ily
+++ b/szablon/struktura-zwrotek-redone.ily
@@ -1,42 +1,42 @@
 \version "2.17.3"
 
 zwrotki = #(define-scheme-function
-		(parser location zwrotki)
-		(markup-list?)
-	(let ((powiekszenie-zwrotek '(1.1 . 1.1))
-				(interlinia '(baseline-skip . 3))
-				(odstepOdNumeruDoZwrotki 1)
-				(odstepMiedzyZwrotkami 2)
-				(counter 2))
-	#{
-		\markup {
-			\fill-line {
-				\scale #powiekszenie-zwrotek {
-					\null
+    (parser location zwrotki)
+    (markup-list?)
+  (let ((powiekszenie-zwrotek '(1.1 . 1.1))
+    (interlinia '(baseline-skip . 3))
+    (odstepOdNumeruDoZwrotki 1)
+    (odstepMiedzyZwrotkami 2)
+    (counter 2))
+  #{
+    \markup {
+      \fill-line {
+        \scale #powiekszenie-zwrotek {
+          \null
 
-					\override #interlinia
-					\column {
-						
-						#(map
-							(lambda (x) #{ \markup {
-							\line {
-								\bold
-								{ #(object->string counter)  "."}
-								\hspace #odstepOdNumeruDoZwrotki
-								#(car zwrotki)
-								#(begin (set! zwrotki (cdr zwrotki)) (set! counter (+ counter 1)) #{ \markup {} #})
-							}
-							\vspace #odstepMiedzyZwrotkami }
-					
-						#})
-						zwrotki)
+          \override #interlinia
+          \column {
+            
+            #(map
+              (lambda (x) #{ \markup {
+              \line {
+                \bold
+                { #(object->string counter)  "."}
+                \hspace #odstepOdNumeruDoZwrotki
+                #(car zwrotki)
+                #(begin (set! zwrotki (cdr zwrotki)) (set! counter (+ counter 1)) #{ \markup {} #})
+              }
+              \vspace #odstepMiedzyZwrotkami }
+          
+            #})
+            zwrotki)
 
-					}
+          }
 
-					\null
+          \null
 
-				}
-			}
-		}
+        }
+      }
+    }
 
-	#}))
+  #}))

--- a/szablon/struktura-zwrotek.ily
+++ b/szablon/struktura-zwrotek.ily
@@ -5,8 +5,8 @@ zwrotki = #(define-scheme-function
 		(markup-list?)
 	(let ((powiekszenie-zwrotek '(1.1 . 1.1))
 				(interlinia '(baseline-skip . 3))
-				(odstepOdNumeruDoZwrotki #{ \markup \vspace #2 #})
-				(odstepMiedzyZwrotkami #{ \markup \hspace #1 #})
+				(odstepOdNumeruDoZwrotki 1)
+				(odstepMiedzyZwrotkami 2)
 				(counter 2))
 	#{
 		\markup {
@@ -22,11 +22,11 @@ zwrotki = #(define-scheme-function
 							\line {
 								\bold
 								{ #(object->string counter)  "."}
-								#odstepOdNumeruDoZwrotki
+								\hspace #odstepOdNumeruDoZwrotki
 								#(car zwrotki)
 								#(begin (set! zwrotki (cdr zwrotki)) (set! counter (+ counter 1)) #{ \markup {} #})
 							}
-							#odstepMiedzyZwrotkami }
+							\vspace #odstepMiedzyZwrotkami }
 					
 						#})
 						zwrotki)

--- a/szablon/struktura-zwrotek.ily
+++ b/szablon/struktura-zwrotek.ily
@@ -1,42 +1,49 @@
 \version "2.17.3"
 
-zwrotki = #(define-scheme-function
-		(parser location zwrotki)
-		(markup-list?)
-	(let ((powiekszenie-zwrotek '(1.1 . 1.1))
-				(interlinia '(baseline-skip . 3))
-				(odstepOdNumeruDoZwrotki 1)
-				(odstepMiedzyZwrotkami 2)
-				(counter 2))
-	#{
-		\markup {
-			\fill-line {
-				\scale #powiekszenie-zwrotek {
-					\null
+\markup {
+  \fill-line {
+    \scale #powiekszenie-zwrotek {
+      \null
 
-					\override #interlinia
-					\column {
-						
-						#(map
-							(lambda (x) #{ \markup {
-							\line {
-								\bold
-								{ #(object->string counter)  "."}
-								\hspace #odstepOdNumeruDoZwrotki
-								#(car zwrotki)
-								#(begin (set! zwrotki (cdr zwrotki)) (set! counter (+ counter 1)) #{ \markup {} #})
-							}
-							\vspace #odstepMiedzyZwrotkami }
-					
-						#})
-						zwrotki)
+      \override #interlinia
+      \column {
+        \line {
+          \bold
+          "2."
+          \odstepOdNumeruDoZwrotki
+          \zwrotkaII
+        }
+        \odstepMiedzyZwrotkami
+        \line {
+          \bold
+          "3."
+          \odstepOdNumeruDoZwrotki
+          \zwrotkaIII
+        }
+        \odstepMiedzyZwrotkami
+      }
 
-					}
+      \null
 
-					\null
+      \override #interlinia
+      \column {
+        \line {
+          \bold
+          "4."
+          \odstepOdNumeruDoZwrotki
+          \zwrotkaIV
+        }
+        \odstepMiedzyZwrotkami
+        \line {
+          \bold
+          "5."
+          \odstepOdNumeruDoZwrotki
+          \zwrotkaV
+        }
+        \odstepMiedzyZwrotkami
+      }
 
-				}
-			}
-		}
-
-	#}))
+      \null
+    }
+  }
+}

--- a/szablon/struktura-zwrotek.ily
+++ b/szablon/struktura-zwrotek.ily
@@ -1,49 +1,42 @@
 \version "2.17.3"
 
-\markup {
-  \fill-line {
-    \scale #powiekszenie-zwrotek {
-      \null
+zwrotki = #(define-scheme-function
+		(parser location zwrotki)
+		(markup-list?)
+	(let ((powiekszenie-zwrotek '(1.1 . 1.1))
+				(interlinia '(baseline-skip . 3))
+				(odstepOdNumeruDoZwrotki #{ \markup \vspace #2 #})
+				(odstepMiedzyZwrotkami #{ \markup \hspace #1 #})
+				(counter 2))
+	#{
+		\markup {
+			\fill-line {
+				\scale #powiekszenie-zwrotek {
+					\null
 
-      \override #interlinia
-      \column {
-        \line {
-          \bold
-          "2."
-          \odstepOdNumeruDoZwrotki
-          \zwrotkaII
-        }
-        \odstepMiedzyZwrotkami
-        \line {
-          \bold
-          "3."
-          \odstepOdNumeruDoZwrotki
-          \zwrotkaIII
-        }
-        \odstepMiedzyZwrotkami
-      }
+					\override #interlinia
+					\column {
+						
+						#(map
+							(lambda (x) #{ \markup {
+							\line {
+								\bold
+								{ #(object->string counter)  "."}
+								#odstepOdNumeruDoZwrotki
+								#(car zwrotki)
+								#(begin (set! zwrotki (cdr zwrotki)) (set! counter (+ counter 1)) #{ \markup {} #})
+							}
+							#odstepMiedzyZwrotkami }
+					
+						#})
+						zwrotki)
 
-      \null
+					}
 
-      \override #interlinia
-      \column {
-        \line {
-          \bold
-          "4."
-          \odstepOdNumeruDoZwrotki
-          \zwrotkaIV
-        }
-        \odstepMiedzyZwrotkami
-        \line {
-          \bold
-          "5."
-          \odstepOdNumeruDoZwrotki
-          \zwrotkaV
-        }
-        \odstepMiedzyZwrotkami
-      }
+					\null
 
-      \null
-    }
-  }
-}
+				}
+			}
+		}
+
+	#}))


### PR DESCRIPTION
Ta wersja: przyjmuje parametr typu markup-list, drukuje elementy w jednej kolumnie, z numerami zwrotek