### PR TITLE
Przyjętą listę zwrotek dzieli na kolumny.

### DIFF
--- a/szablon/struktura-zwrotek-kolumny.ily
+++ b/szablon/struktura-zwrotek-kolumny.ily
@@ -13,9 +13,7 @@ podzielNaKolumny = #(define-scheme-function
 zwrotki = #(define-scheme-function
     (parser location liczbaKolumn counter powiekszenie interlinia odstepMiedzyZwrotkami odstepOdNumeruDoZwrotki lista-zwrotek)
     ((number? 2) (number? 2) (number? 1.1) (number? 3) (number? 2) (number? 1) markup-list?)
-  (let* ((powiekszenie-zwrotek '(1.1 . 1.1))
-    
-    (kolumna-markup (define-scheme-function
+  (let* ((kolumna-markup (define-scheme-function
     (parser location lista-zwrotek)
     (markup-list?)
     #{ \markup {

--- a/szablon/struktura-zwrotek-kolumny.ily
+++ b/szablon/struktura-zwrotek-kolumny.ily
@@ -1,55 +1,5 @@
 \version "2.19.82"
 
-debug = #(define-scheme-function
-    (parser location lista-zwrotek liczbaKolumn)
-    (markup-list? number?)
-  (let ((powiekszenie-zwrotek '(1.1 . 1.1))
-    (interlinia '(baseline-skip . 3))
-    (odstepOdNumeruDoZwrotki 1)
-    (odstepMiedzyZwrotkami 2)
-    (counter 2)
-    (out #{ \markup {} #}))
-  #{
-    \markup {
-      \fill-line {
-        \scale #powiekszenie-zwrotek {
-          \null
-
-          #(map
-            (lambda (kolumna) #{ \markup {
-          
-          \override #interlinia
-          \column {
-            
-            #(map
-              (lambda (zwrotka) #{ \markup {
-              \line {
-                \bold
-                \concat { #(object->string counter)  "."}
-                \hspace #odstepOdNumeruDoZwrotki
-                #zwrotka
-                #(begin (set! counter (+ counter 1)) #{ \markup {} #})
-              }
-              \vspace #odstepMiedzyZwrotkami
-            }
-          
-            #})
-            kolumna)
-
-          }
-
-          \null
-          
-          }
-          #})
-            (podzielNaKolumny lista-zwrotek liczbaKolumn))
-
-        }
-      }
-    }
-
-  #}))
-  
 podzielNaKolumny = #(define-scheme-function
     (parser location lista-zwrotek liczbaKolumn)
     (markup-list? number?)
@@ -63,49 +13,40 @@ podzielNaKolumny = #(define-scheme-function
 zwrotki = #(define-scheme-function
     (parser location lista-zwrotek liczbaKolumn)
     (markup-list? number?)
-  (let ((powiekszenie-zwrotek '(1.1 . 1.1))
+  (let* ((powiekszenie-zwrotek '(1.1 . 1.1))
     (interlinia '(baseline-skip . 3))
     (odstepOdNumeruDoZwrotki 1)
     (odstepMiedzyZwrotkami 2)
     (counter 2)
-    (out #{ \markup {} #}))
-  #{
-    \markup {
-      \fill-line {
-        \scale #powiekszenie-zwrotek {
-          \null
-
-          #(map
-            (lambda (kolumna) #{ \markup {
-          
-          \override #interlinia
-          \column {
-            
-            #(map
-              (lambda (zwrotka) #{ \markup {
-              \line {
+    
+    (kolumna-markup (define-scheme-function
+    (parser location lista-zwrotek)
+    (markup-list?)
+    #{ \markup {
+        \override #interlinia
+        \column #(apply append (map 
+            (lambda (zwrotka) (list 
+              #{ \markup {
                 \bold
                 \concat { #(object->string counter)  "."}
                 \hspace #odstepOdNumeruDoZwrotki
                 #zwrotka
-                #(begin (set! counter (+ counter 1)) #{ \markup {} #})
-              }
-              \vspace #odstepMiedzyZwrotkami
-            }
-          
-            #})
-            kolumna)
+                #(begin (set! counter (+ counter 1)) (markup) )}
+              #}
+              #{\markup { \vspace #odstepMiedzyZwrotkami } #}
+            )) lista-zwrotek
+            
+            ))}
+    #})))
+  #{ \markup {
+      \fill-line
+        \scale #powiekszenie-zwrotek
+        #(append (list #{\markup \null #}) 
+          (apply append (map 
+            (lambda (kolumna) (list 
+              (kolumna-markup kolumna)
+              #{\markup \null #}
+            )) (podzielNaKolumny lista-zwrotek liczbaKolumn)
+            )))
 
-          }
-
-          \null
-          
-          }
-          #})
-            (podzielNaKolumny lista-zwrotek liczbaKolumn))
-
-        }
-      }
-    }
-
-  #}))
+   }#}))

--- a/szablon/struktura-zwrotek-kolumny.ily
+++ b/szablon/struktura-zwrotek-kolumny.ily
@@ -11,19 +11,15 @@ podzielNaKolumny = #(define-scheme-function
 
 
 zwrotki = #(define-scheme-function
-    (parser location lista-zwrotek liczbaKolumn)
-    (markup-list? number?)
+    (parser location liczbaKolumn counter powiekszenie interlinia odstepMiedzyZwrotkami odstepOdNumeruDoZwrotki lista-zwrotek)
+    ((number? 2) (number? 2) (number? 1.1) (number? 3) (number? 2) (number? 1) markup-list?)
   (let* ((powiekszenie-zwrotek '(1.1 . 1.1))
-    (interlinia '(baseline-skip . 3))
-    (odstepOdNumeruDoZwrotki 1)
-    (odstepMiedzyZwrotkami 2)
-    (counter 2)
     
     (kolumna-markup (define-scheme-function
     (parser location lista-zwrotek)
     (markup-list?)
     #{ \markup {
-        \override #interlinia
+        \override #`(baseline-skip . ,interlinia)
         \column #(apply append (map 
             (lambda (zwrotka) (list 
               #{ \markup {
@@ -40,7 +36,7 @@ zwrotki = #(define-scheme-function
     #})))
   #{ \markup {
       \fill-line
-        \scale #powiekszenie-zwrotek
+        \scale #`(,powiekszenie . ,powiekszenie)
         #(append (list #{\markup \null #}) 
           (apply append (map 
             (lambda (kolumna) (list 

--- a/szablon/struktura-zwrotek-kolumny.ily
+++ b/szablon/struktura-zwrotek-kolumny.ily
@@ -1,0 +1,111 @@
+\version "2.17.3"
+
+debug = #(define-scheme-function
+    (parser location lista-zwrotek liczbaKolumn)
+    (markup-list? number?)
+  (let ((powiekszenie-zwrotek '(1.1 . 1.1))
+    (interlinia '(baseline-skip . 3))
+    (odstepOdNumeruDoZwrotki 1)
+    (odstepMiedzyZwrotkami 2)
+    (counter 2)
+    (out #{ \markup {} #}))
+  #{
+    \markup {
+      \fill-line {
+        \scale #powiekszenie-zwrotek {
+          \null
+
+          #(map
+            (lambda (kolumna) #{ \markup {
+          
+          \override #interlinia
+          \column {
+            
+            #(map
+              (lambda (zwrotka) #{ \markup {
+              \line {
+                \bold
+                \concat { #(object->string counter)  "."}
+                \hspace #odstepOdNumeruDoZwrotki
+                #zwrotka
+                #(begin (set! counter (+ counter 1)) #{ \markup {} #})
+              }
+              \vspace #odstepMiedzyZwrotkami
+            }
+          
+            #})
+            kolumna)
+
+          }
+
+          \null
+          
+          }
+          #})
+            (podzielNaKolumny lista-zwrotek liczbaKolumn))
+
+        }
+      }
+    }
+
+  #}))
+  
+podzielNaKolumny = #(define-scheme-function
+    (parser location lista-zwrotek liczbaKolumn)
+    (markup-list? number?)
+  (let* ((liczba-zwrotek (length lista-zwrotek))
+        (wysokosc-kolumny (+ (quotient liczba-zwrotek liczbaKolumn) (if (= (modulo liczba-zwrotek liczbaKolumn) 0) 0 1))))
+  (if (null? lista-zwrotek) (list '())
+  (if (= liczbaKolumn 1) (list lista-zwrotek)
+    (append (list (list-head lista-zwrotek wysokosc-kolumny)) (podzielNaKolumny (list-tail lista-zwrotek wysokosc-kolumny) (- liczbaKolumn 1)) )))))
+
+
+zwrotki = #(define-scheme-function
+    (parser location lista-zwrotek liczbaKolumn)
+    (markup-list? number?)
+  (let ((powiekszenie-zwrotek '(1.1 . 1.1))
+    (interlinia '(baseline-skip . 3))
+    (odstepOdNumeruDoZwrotki 1)
+    (odstepMiedzyZwrotkami 2)
+    (counter 2)
+    (out #{ \markup {} #}))
+  #{
+    \markup {
+      \fill-line {
+        \scale #powiekszenie-zwrotek {
+          \null
+
+          #(map
+            (lambda (kolumna) #{ \markup {
+          
+          \override #interlinia
+          \column {
+            
+            #(map
+              (lambda (zwrotka) #{ \markup {
+              \line {
+                \bold
+                \concat { #(object->string counter)  "."}
+                \hspace #odstepOdNumeruDoZwrotki
+                #zwrotka
+                #(begin (set! counter (+ counter 1)) #{ \markup {} #})
+              }
+              \vspace #odstepMiedzyZwrotkami
+            }
+          
+            #})
+            kolumna)
+
+          }
+
+          \null
+          
+          }
+          #})
+            (podzielNaKolumny lista-zwrotek liczbaKolumn))
+
+        }
+      }
+    }
+
+  #}))

--- a/szablon/struktura-zwrotek-kolumny.ily
+++ b/szablon/struktura-zwrotek-kolumny.ily
@@ -1,4 +1,4 @@
-\version "2.17.3"
+\version "2.19.82"
 
 debug = #(define-scheme-function
     (parser location lista-zwrotek liczbaKolumn)

--- a/szablon/test.ly
+++ b/szablon/test.ly
@@ -1,0 +1,32 @@
+\version "2.19.82"
+
+\include "struktura-zwrotek-kolumny.ily"
+
+muzyka = \markuplist{
+	\column {
+  "Salve fons vere, plene bonis veris,"
+  "Nam quando in te Deum ipsum geris:"
+  "Divine in te geris bonitatis,"
+  "Præmia gratis."
+}
+	\column {
+  "Salve o manna cælitus descendens,"
+  "Omnem saporem in te comprehendens:"
+  "Est in te omnis gustus suavitatis,"
+  "Et voluptatis."
+}
+	\column {
+  "Salve, o dulce paradisi lignum,"
+  "Tu verus vitæ fructus es et signum:"
+  "Quisquis te gustat mortem non timebit,"
+  "Quamvis videbit."
+}
+	\column {
+  "Salve o unicum cordis levamen,"
+  "Et afflictorum dulce consolamen,"
+  "Te cum lachrymis pijs quæritamus,"
+  "Te invocamus."
+}
+}
+
+\zwrotki \muzyka 2

--- a/szablon/test.ly
+++ b/szablon/test.ly
@@ -29,4 +29,4 @@ muzyka = \markuplist{
 }
 }
 
-\zwrotki \muzyka 2
+\zwrotki \muzyka


### PR DESCRIPTION
Z jakiegoś powodu kompilacja zależy od wersji LP, stąd zmiana wersji.
Nie działa jeszcze wyśrodkowanie. Podejrzewam, że z powodu paru dodanych #:line w markupie. Nie potrafię tego zmienić - dodawane są dodatkowe przy każdym wywołaniu bloku \markup. Czy jest jakaś forma generowania w Scheme'ie tekstu w markup mode, tak jak dla lilypondowego kodu jest #{…#}? 